### PR TITLE
remove username column from posts table

### DIFF
--- a/db/migrate/20220120094157_remove_username_from_posts.rb
+++ b/db/migrate/20220120094157_remove_username_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveUsernameFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :posts, :username, :string
+  end
+end


### PR DESCRIPTION
just add the migration to remove the username column in the posts table
after merge run 'bin/rails db:migrate' to update the database