### PR TITLE
Update procfile to migrate db on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,3 @@
 web: bundle exec puma -C config/puma.rb
+
+release: bundle exec rake db:migrate


### PR DESCRIPTION
Updated the procfile to make heroku run the db migrations on release, this should fix the bug causing the likeable column not being in the database of the deployment.