### PR TITLE
Friend request notification patch 

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,6 +9,9 @@ class Comment < ApplicationRecord
 
   has_many :likes, as: :likeable, dependent: :destroy
 
+  has_many :notifications, as: :recipient, dependent: :destroy
+  has_noticed_notifications param_name: :parent, destroy: true, model_name: "Notification"
+
   after_create_commit :notify_recipient
   
   private
@@ -17,6 +20,6 @@ class Comment < ApplicationRecord
     recipient = User.find(post.user_id)
     sender = User.find(user_id)
     commenter = "#{sender.name} #{sender.surname}"
-    CommentNotification.with(message: self, post: post, commenter: commenter).deliver_later(recipient) unless recipient == sender
+    CommentNotification.with(parent: self, post: post, commenter: commenter).deliver_later(recipient) unless recipient == sender
   end
 end

--- a/app/models/friend_request.rb
+++ b/app/models/friend_request.rb
@@ -6,6 +6,9 @@ class FriendRequest < ApplicationRecord
   validate :not_friends
   validate :not_pending
 
+  has_many :notifications, as: :recipient, dependent: :destroy
+  has_noticed_notifications param_name: :parent, destroy: true, model_name: "Notification"
+
   def accept
     user.friends << friend
     destroy
@@ -33,6 +36,6 @@ class FriendRequest < ApplicationRecord
     recipient = User.find(friend.id)
     sender = User.find(user_id)
     requester = "#{sender.name} #{sender.surname}"
-    FriendRequestNotification.with(message: self, sender: sender, requester: requester).deliver_later(recipient) unless recipient == sender
+    FriendRequestNotification.with(parent: self, message: self, sender: sender, requester: requester).deliver_later(recipient) unless recipient == sender
   end
 end

--- a/app/notifications/friend_request_notification.rb
+++ b/app/notifications/friend_request_notification.rb
@@ -30,6 +30,6 @@ class FriendRequestNotification < Noticed::Base
   end
   #
   def url
-    users_profiles_path
+    friend_requests_path
   end
 end

--- a/spec/features/notification-tests/notification_spec.rb
+++ b/spec/features/notification-tests/notification_spec.rb
@@ -81,4 +81,53 @@ RSpec.feature "Notifications", type: :feature do
     click_button('Remove all notifications')
     expect(page).to_not have_content("You have a new comment")
   end
+
+  scenario "a user sees a notification after receiving a friend request" do
+    # User 1 comments on user 2's post
+    visit '/'
+    fill_in 'profile_about', with: 'Im a cat!'
+    click_button 'Create Profile'
+    logout(@user1)
+
+    # User 2 adds user 1
+    login_as(@user2, :scope => :user)
+    visit '/'
+    fill_in 'profile_about', with: 'Im a dog!'
+    click_button 'Create Profile'
+    visit '/users/profiles'
+    click_button 'Add Friend'
+    logout(@user2)
+
+    # # User 1 sees a notification
+    login_as(@user1, :scope => :user)
+    visit "/users/#{@user2.id}/notifications"
+    expect(page).to have_content("You have a new friend request")
+  end
+
+  scenario "a user sees no notification after accepting a friend request" do
+    # User 1 comments on user 2's post
+    visit '/'
+    fill_in 'profile_about', with: 'Im a cat!'
+    click_button 'Create Profile'
+    logout(@user1)
+
+    # User 2 adds user 1
+    login_as(@user2, :scope => :user)
+    visit '/'
+    fill_in 'profile_about', with: 'Im a dog!'
+    click_button 'Create Profile'
+    visit '/users/profiles'
+    click_button 'Add Friend'
+    logout(@user2)
+
+    # User 1 sees a notification and accepts
+    login_as(@user1, :scope => :user)
+    visit "/users/#{@user1.id}/notifications"
+    click_on('You have a new friend request from name surname.')
+    click_button('Accept')
+
+    # User 1 sees no notification
+    visit "/users/#{@user1.id}/notifications"
+    expect(page).to_not have_content("You have a new friend request")
+  end
 end


### PR DESCRIPTION
Fix notifications not being destroyed when friend requests are accepted